### PR TITLE
add ability for retry strategies to override default retry delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,12 @@ fetch(url, {
     * {function} `shouldRetry`: Should return a `Promise` that resolves to true if the information provided by the client warrants a retry. The function will be passed a single argument: an object consisting of the following properties:
       * {number} attempts: The number of times the current request has been sent.
       * {number} maxAttempts: The _default_ maximum number of attempts as provided in the client's options.
+      * {number} delay: The _default_ time, in milliseconds, that the client should delay between retries.
       * {number} delayMultiple: The _default_ multiple as provided in the client's options.
       * {*} response: Response that was the result of the request. This will be the raw response from the underlying HTTP library.
       * {string} url: URL to which the client sent the HTTP request that generated the response.
       * {object} options: Simple object containing the raw options that were given to the underlying HTTP library.
+    * {function} `getDelay`: Should return a `Promise` that resolves with the amount of time, in milliseconds, that the client should wait before retrying the request. This value will be used in conjunction with the delay multiple to exponentially delay subsequent retries. The function will be called with a single argument: an object matching the one described in the `shouldRetry` function. If not specified, the value will default to the delay provided in the client's retry options.
     * {function} `getDelayMultiple`: Should return a `Promise` that resolves to the multiple to use when calculating the amount of time to delay before retrying the request. The function will be called with a single argument: an object matching the object described in the `shouldRetry` function. If not specified the value will default to the multiple provided in the client's retry options.
     * {function} `getMaxRetries`: Should return a `Promise` that resolves to the maximum number of times that a given request should be made. The function will be called with a single argument: an object matching the object described in the `shouldRetry` function. If not specified, the value will default to the number provided in the client's retry options. Note that `-1` indicates the client should continue to retry indefinitely; _use this option with extreme care_.
   * {number} `count`: The maximum number of times the client will retry a given request. Note that this is a _default_ value and will not necessarily be respected by all retry strategies. Default: 3.

--- a/src/http-client-utils.js
+++ b/src/http-client-utils.js
@@ -44,6 +44,7 @@ async function retryWithStrategies(httpOptions, backend, response, attempts) {
       attempts,
       maxAttempts: httpOptions.getMaxRetries(),
       delayMultiple: httpOptions.getRetryDelayMultiple(),
+      delay: httpOptions.getRetryDelay(),
     };
     const shouldRetry = await strategy.shouldRetry(retryOptions);
     if (strategy.constructor) {
@@ -54,13 +55,13 @@ async function retryWithStrategies(httpOptions, backend, response, attempts) {
     if (shouldRetry) {
       const delayMultiple = await strategy.getRetryDelayMultiple(retryOptions);
       const maxRetries = await strategy.getMaxRetryCount(retryOptions);
+      const delay = await strategy.getRetryDelay(retryOptions);
 
       if (attempts >= maxRetries && maxRetries >= 0) {
         return false;
       }
 
-      let retryDelay =
-        httpOptions.getRetryDelay() * Math.pow(delayMultiple, attempts - 1);
+      let retryDelay = delay * Math.pow(delayMultiple, attempts - 1);
       return retryDelay;
     }
   }

--- a/src/retry-strategies/retry-strategy.js
+++ b/src/retry-strategies/retry-strategy.js
@@ -105,6 +105,20 @@ class RetryStrategy {
   }
 
   /**
+   * Retrieves the amount of time, in milliseconds, that the retry should be delayed. Note
+   * that the retry delay multiple will be used to expentially increase this delay with
+   * each retry.
+   *
+   * @param {RetryOptions} retryOptions Information about the current request, which
+   *  can be used to determine the delay.
+   * @returns {Promise<number>} Retry delay.
+   */
+  async getRetryDelay(retryOptions) {
+    const { getDelay = async () => retryOptions.delay } = this[PRIVATE].options;
+    return getDelay(retryOptions);
+  }
+
+  /**
    * Retrieves the maximum number of times that a request should be retried according to
    * the strategy.
    *

--- a/test/http-client-utils.test.js
+++ b/test/http-client-utils.test.js
@@ -1,0 +1,110 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const assert = require("assert");
+
+const { retryWithStrategies } = require("../src/http-client-utils");
+const HttpBackend = require("../src/http-backends/http-backend");
+const HttpOptions = require("../src/http-options");
+const HttpResponse = require("../src/http-response");
+
+describe("http client utils tests", function () {
+  it("test retry with no strategies", async function () {
+    const backend = new HttpBackend();
+    const options = new HttpOptions();
+    const response = new HttpResponse({ status: 200 });
+    const delay = await retryWithStrategies(options, backend, response, 1);
+    assert.ok(!delay);
+  });
+
+  it("test retry with 500 error", async function () {
+    const backend = new HttpBackend();
+    const options = new HttpOptions();
+    const response = new HttpResponse({ status: 500 });
+    const delay = await retryWithStrategies(options, backend, response, 1);
+    assert.strictEqual(delay, 1000);
+  });
+
+  it("test retry with custom strategy", async function () {
+    const backend = new HttpBackend();
+    const options = new HttpOptions({
+      cloudClient: {
+        retry: {
+          strategies: [
+            {
+              shouldRetry: () => true,
+            },
+          ],
+        },
+      },
+    });
+    const response = new HttpResponse({ status: 200 });
+    const delay = await retryWithStrategies(options, backend, response, 1);
+    assert.strictEqual(delay, 1000);
+  });
+
+  it("test retry with custom delay multiple strategy", async function () {
+    const backend = new HttpBackend();
+    const options = new HttpOptions({
+      cloudClient: {
+        retry: {
+          strategies: [
+            {
+              shouldRetry: () => true,
+              getDelayMultiple: () => 10,
+            },
+          ],
+        },
+      },
+    });
+    const response = new HttpResponse({ status: 200 });
+    const delay = await retryWithStrategies(options, backend, response, 2);
+    assert.strictEqual(delay, 10000);
+  });
+
+  it("test retry with custom max retries strategy", async function () {
+    const backend = new HttpBackend();
+    const options = new HttpOptions({
+      cloudClient: {
+        retry: {
+          strategies: [
+            {
+              shouldRetry: () => true,
+              getMaxRetries: () => 1,
+            },
+          ],
+        },
+      },
+    });
+    const response = new HttpResponse({ status: 200 });
+    const delay = await retryWithStrategies(options, backend, response, 2);
+    assert.strictEqual(delay, false);
+  });
+
+  it("test retry with custom delay duration strategy", async function () {
+    const backend = new HttpBackend();
+    const options = new HttpOptions({
+      cloudClient: {
+        retry: {
+          strategies: [
+            {
+              shouldRetry: () => true,
+              getDelay: () => 1,
+            },
+          ],
+        },
+      },
+    });
+    const response = new HttpResponse({ status: 200 });
+    const delay = await retryWithStrategies(options, backend, response, 1);
+    assert.strictEqual(delay, 1);
+  });
+});

--- a/test/retry-strategies/retry-strategy.test.js
+++ b/test/retry-strategies/retry-strategy.test.js
@@ -30,4 +30,18 @@ describe("retry strategy tests", function () {
       }))
     );
   });
+
+  it("test retry strategy delay default", async function () {
+    const retryStrategy = new RetryStrategy();
+    const retryDelay = await retryStrategy.getRetryDelay({ delay: 1000 });
+    assert.strictEqual(retryDelay, 1000);
+  });
+
+  it("test retry strategy delay specified", async function () {
+    const retryStrategy = new RetryStrategy({
+      getDelay: () => 500,
+    });
+    const retryDelay = await retryStrategy.getRetryDelay({ delay: 1000 });
+    assert.strictEqual(retryDelay, 500);
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There may be cases where an individual retry strategy needs to override the default delay between retries. For example, a strategy may require an _immediate_ retry, so there would be no delay between retry attempts.

This PR adds a new `getDelay` method to retry strategies, so that a custom strategy can specify its own delay.

## Related Issue

#4 

## Motivation and Context

Trying to create a retry strategy that refreshes an OAuth2 token if a request fails with 401. The strategy refreshes the token, then wants to immediately retry the request with the new token.

## How Has This Been Tested?

New unit tests. Existing unit tests and e2e tests pass. Manually tested locally with the refresh token scenario described above.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
