### PR TITLE
feat: honor server's retry-after header

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ delay multiple and wait 5 seconds.
 
 This can still be overridden through the `shouldRetry` method, which will receive the server's `Retry-After` value as the default delay.
 
+On subsequent retries, the client will fall back to its default behavior if the server does not provide additional `Retry-After` headers.
+
 ### Example Retry Strategies
 
 The following client will retry a request up to 5 times if the response code is `404`:

--- a/README.md
+++ b/README.md
@@ -185,6 +185,14 @@ client makes a request, it will pass the response through its list of strategies
 
 By default the client will retry a request up to a maximum number of times, exponentially delaying the amount of time between each retry. However, this behavior can be overridden by individual strategies.
 
+### Retry-After Header
+
+If a server responds with a `Retry-After` header, the client will use that value above all other retry options. For example, assume the client has been configured to delay
+1 second between retries, with a delay multiple of 2; when a server responds with a `Retry-After` value of 5 on the second retry, the client will ignore the delay and
+delay multiple and wait 5 seconds.
+
+This can still be overridden through the `shouldRetry` method, which will receive the server's `Retry-After` value as the default delay.
+
 ### Example Retry Strategies
 
 The following client will retry a request up to 5 times if the response code is `404`:

--- a/e2e/all-methods.test.js
+++ b/e2e/all-methods.test.js
@@ -557,5 +557,28 @@ examples of how to use the client. The relevant example code will be flagged wit
         }
       );
     });
+
+    it(`${verifierName}: Retry-After header`, async () => {
+      webserver.addResponses([
+        {
+          statusCode: 503,
+          headers: {
+            "Retry-After": 3,
+          },
+        },
+        {
+          statusCode: 200,
+          body: "Testing",
+        },
+      ]);
+      const response = await client({
+        url: HOST,
+      });
+      verifier.verifySuccess(response);
+      const { options = {} } = response.cloudClient;
+      const { cloudClient = {} } = options;
+      assert.strictEqual(cloudClient.retries, 1);
+      assert.strictEqual(cloudClient.retryWait, 3000);
+    });
   });
 });

--- a/src/http-backends/fetch-backend.js
+++ b/src/http-backends/fetch-backend.js
@@ -13,6 +13,7 @@ const { AbortController } = require("node-abort-controller");
 
 const HttpBackend = require("./http-backend");
 const FetchHttpOptions = require("./fetch-http-options");
+const FetchHttpResponse = require("./fetch-http-response");
 const { parseMultipleFetchSetCookieHeaders } = require("../http-utils");
 const typedefs = require("../typedefs");
 
@@ -71,6 +72,10 @@ class FetchBackend extends HttpBackend {
 
   createHttpOptions(options) {
     return new FetchHttpOptions(options, this.getClientOptions());
+  }
+
+  createHttpResponse(response, error) {
+    return new FetchHttpResponse(response, error);
   }
 
   /**

--- a/src/http-backends/fetch-http-response.js
+++ b/src/http-backends/fetch-http-response.js
@@ -14,8 +14,9 @@ const HttpResponse = require("../http-response");
 class FetchHttpResponse extends HttpResponse {
   getHeaders() {
     const { headers } = this.getRawResponse();
-    const headerLookup = {};
+    let headerLookup;
     if (headers && headers.keys) {
+      headerLookup = {};
       for (const headerName of headers.keys()) {
         headerLookup[headerName] = headers.get(headerName);
       }

--- a/test/http-backends/fetch-backend.test.js
+++ b/test/http-backends/fetch-backend.test.js
@@ -110,4 +110,11 @@ describe("fetch backend tests", function () {
     assert.ok(options);
     assert.strictEqual(options.constructor.name, "FetchHttpOptions");
   });
+
+  it("test create http response", function () {
+    const backend = new FetchBackend({}, fetch);
+    const response = backend.createHttpResponse({});
+    assert.ok(response);
+    assert.strictEqual(response.constructor.name, "FetchHttpResponse");
+  });
 });

--- a/test/http-backends/fetch-http-response.test.js
+++ b/test/http-backends/fetch-http-response.test.js
@@ -19,13 +19,13 @@ describe("fetch http response tests", function () {
   it("test get headers", function () {
     let response = new FetchHttpResponse({});
     let lookup = response.getHeaders();
-    assert.strictEqual(Object.keys(lookup).length, 0);
+    assert.strictEqual(lookup, undefined);
 
     response = new FetchHttpResponse({
       header: "value",
     });
     lookup = response.getHeaders();
-    assert.strictEqual(Object.keys(lookup).length, 0);
+    assert.strictEqual(lookup, undefined);
 
     response = new FetchHttpResponse({
       headers: {

--- a/test/http-client-utils.test.js
+++ b/test/http-client-utils.test.js
@@ -11,7 +11,10 @@ governing permissions and limitations under the License.
 
 const assert = require("assert");
 
-const { retryWithStrategies } = require("../src/http-client-utils");
+const {
+  retryWithStrategies,
+  getRetryAfter,
+} = require("../src/http-client-utils");
 const HttpBackend = require("../src/http-backends/http-backend");
 const HttpOptions = require("../src/http-options");
 const HttpResponse = require("../src/http-response");
@@ -20,7 +23,7 @@ describe("http client utils tests", function () {
   it("test retry with no strategies", async function () {
     const backend = new HttpBackend();
     const options = new HttpOptions();
-    const response = new HttpResponse({ status: 200 });
+    const response = new HttpResponse({ status: 200, headers: {} });
     const delay = await retryWithStrategies(options, backend, response, 1);
     assert.ok(!delay);
   });
@@ -28,7 +31,7 @@ describe("http client utils tests", function () {
   it("test retry with 500 error", async function () {
     const backend = new HttpBackend();
     const options = new HttpOptions();
-    const response = new HttpResponse({ status: 500 });
+    const response = new HttpResponse({ status: 500, headers: {} });
     const { delay } = await retryWithStrategies(options, backend, response, 1);
     assert.strictEqual(delay, 1000);
   });
@@ -46,7 +49,7 @@ describe("http client utils tests", function () {
         },
       },
     });
-    const response = new HttpResponse({ status: 200 });
+    const response = new HttpResponse({ status: 200, headers: {} });
     const { delay } = await retryWithStrategies(options, backend, response, 1);
     assert.strictEqual(delay, 1000);
   });
@@ -65,7 +68,7 @@ describe("http client utils tests", function () {
         },
       },
     });
-    const response = new HttpResponse({ status: 200 });
+    const response = new HttpResponse({ status: 200, headers: {} });
     const { delay } = await retryWithStrategies(options, backend, response, 2);
     assert.strictEqual(delay, 10000);
   });
@@ -84,7 +87,7 @@ describe("http client utils tests", function () {
         },
       },
     });
-    const response = new HttpResponse({ status: 200 });
+    const response = new HttpResponse({ status: 200, headers: {} });
     const delay = await retryWithStrategies(options, backend, response, 2);
     assert.strictEqual(delay, false);
   });
@@ -103,7 +106,7 @@ describe("http client utils tests", function () {
         },
       },
     });
-    const response = new HttpResponse({ status: 200 });
+    const response = new HttpResponse({ status: 200, headers: {} });
     const { delay, options: requestOptions } = await retryWithStrategies(
       options,
       backend,
@@ -130,7 +133,7 @@ describe("http client utils tests", function () {
         },
       },
     });
-    const response = new HttpResponse({ status: 200 });
+    const response = new HttpResponse({ status: 200, headers: {} });
     const { options: requestOptions } = await retryWithStrategies(
       options,
       backend,
@@ -138,5 +141,60 @@ describe("http client utils tests", function () {
       1
     );
     assert.deepStrictEqual(requestOptions, { hello: "world!" });
+  });
+
+  it("test retry with Retry-After header", async function () {
+    const backend = new HttpBackend();
+    const options = new HttpOptions({
+      cloudClient: {
+        retry: {
+          delay: 1500,
+          delayMultiple: 5,
+          strategies: [
+            {
+              shouldRetry: (info) => {
+                assert.strictEqual(info.delayMultiple, 1);
+                assert.strictEqual(info.delay, 5000);
+                return true;
+              },
+              getRequestOptions: () => {
+                return { hello: "world!" };
+              },
+            },
+          ],
+        },
+      },
+    });
+    const response = new HttpResponse({
+      status: 200,
+      headers: {
+        "Retry-After": "5",
+      },
+    });
+    const { options: requestOptions } = await retryWithStrategies(
+      options,
+      backend,
+      response,
+      1
+    );
+    assert.deepStrictEqual(requestOptions, { hello: "world!" });
+  });
+
+  it("test get retry after", () => {
+    let response = new HttpResponse({ status: 200 });
+    // no headers
+    assert.ok(!getRetryAfter(response));
+    // no retry-after header
+    response = new HttpResponse({ status: 200, headers: {} });
+    assert.ok(!getRetryAfter(response));
+    // retry-after header
+    response = new HttpResponse({ status: 200, headers: { "retry-after": 1 } });
+    assert.strictEqual(getRetryAfter(response), 1000);
+    // Retry-After header
+    response = new HttpResponse({
+      status: 200,
+      headers: { "Retry-After": "3" },
+    });
+    assert.strictEqual(getRetryAfter(response), 3000);
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Extends the library so that it will honor a server's `Retry-After` header, if provided.

## Related Issue

#9 

## Motivation and Context

Some server's may provide instructions for clients when it comes to how long they should wait before retrying a request.

## How Has This Been Tested?

Unit tests and e2e tests pass. New e2e test that uses `Retry-After` header has been added.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
